### PR TITLE
Include more than 2 steps in the generated PDF

### DIFF
--- a/polarsteps_data_parser/pdf_generator.py
+++ b/polarsteps_data_parser/pdf_generator.py
@@ -32,7 +32,7 @@ class PDFGenerator:
         self.generate_title_page(trip)
 
         no_of_steps = len(trip.steps)
-        for i, step in enumerate(trip.steps[:2], start=1):
+        for i, step in enumerate(trip.steps, start=1):
             logger.debug(f"{i}/{no_of_steps} generating pages for step {step.name}")
             self.generate_step_pages(step)
 


### PR DESCRIPTION
It does not look useful to make the loop over the step stop after 2 entries.